### PR TITLE
Addition of "multi-template" and "manual" option for processing.py and processing_with_mes_generation.py

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -234,7 +234,10 @@ def find_objects_by_manual_annotation(stitched_ds):
     # after the viewer is closed, the following will be executed:
     coords = viewer.layers['Points'].data
     n_objects = len(coords)
-    logging.info(f'{n_objects} coordinates were annotated...')
+    if n_objects == 0:
+        logging.warning('no coordinates were annotated...')
+    else:
+        logging.info(f'{n_objects} coordinates were annotated...')
     selected_objects = np.empty(np.shape(stitched_ds))
     selected_objects[coords[:, 0].astype('int'),
                      coords[:, 1].astype('int')] = 1

--- a/processing.py
+++ b/processing.py
@@ -231,6 +231,7 @@ def find_objects_by_manual_annotation(stitched_ds):
     low, high = np.quantile(stitched_ds, [0.0001, 0.9999])
     viewer.layers['stitched_ds'].contrast_limits = [low, high]
     viewer.add_points(None)
+    viewer.layers['Points'].mode = 'add'
     napari.run()
 
     # after the viewer is closed, the following will be executed:

--- a/processing.py
+++ b/processing.py
@@ -228,6 +228,9 @@ def find_objects_by_manual_annotation(stitched_ds):
 
     viewer = napari.Viewer()
     viewer.add_image(stitched_ds)
+    # rescale stitched image
+    low, high = np.quantile(stitched_ds, [0.0001, 0.9999])
+    viewer.layers['stitched_ds'].contrast_limits = [low, high]
     viewer.add_points(None)
     napari.run()
 

--- a/processing.py
+++ b/processing.py
@@ -225,7 +225,6 @@ def find_objects_by_threshold(stitched_ds, sigma, minimum_object_size):
 
 
 def find_objects_by_manual_annotation(stitched_ds):
-
     viewer = napari.Viewer()
     viewer.add_image(stitched_ds)
     # rescale stitched image

--- a/procressing_with_mes_generation.py
+++ b/procressing_with_mes_generation.py
@@ -24,8 +24,11 @@ from utils import available_wells, load_well, stitch_arrays, unstitch_arrays, ge
     get_xml_action_list_from_file, get_pixel_scale, get_xml_timeline_template, get_xml_point, get_xml_targetwell, \
     XML_NAMESPACES, replace_namespace_tag, ET
 import random
-from processing import find_objects_by_threshold, find_objects_by_template_matching, \
-    find_objects_by_multiple_template_matching, plot_results
+from processing import find_objects_by_threshold, \
+    find_objects_by_template_matching, \
+    find_objects_by_multiple_template_matching, \
+    find_objects_by_manual_annotation, \
+    plot_results
 import warnings
 
 X_OFFSET_PX = -140
@@ -45,7 +48,7 @@ def main():
     parser.add_argument('-p', '--plot_output', type=bool, default=True,
                         help='Whether to generate plots of the results.')
     parser.add_argument('-m', '--method', type=str, default='template',
-                        help="""Method to use for object detection. Either `template`, 'multi-template' or `threshold`. Make sure you 
+                        help="""Method to use for object detection. Either `template`, 'multi-template', `threshold` or 'manual'. Make sure you 
                         specify the required arguments for the method you chose.""")
     parser.add_argument('-nx', '--n_tiles_x', type=int, default=4, help='Number of tiles per well in x.')
     parser.add_argument('-ny', '--n_tiles_y', type=int, default=5, help='Number of tiles per well in y.')
@@ -114,6 +117,9 @@ def main():
                                                              sigma=args.sigma,
                                                              minimum_object_size=args.minimum_object_size,
                                                              )
+        elif args.method == 'manual':
+            objects, non_objects = find_objects_by_manual_annotation(stitched_ds,
+                                                                     )
         else:
             raise NotImplementedError(f"Method `{args.method}` is not available. Use either `template` or `threshold`.")
 

--- a/procressing_with_mes_generation.py
+++ b/procressing_with_mes_generation.py
@@ -24,7 +24,8 @@ from utils import available_wells, load_well, stitch_arrays, unstitch_arrays, ge
     get_xml_action_list_from_file, get_pixel_scale, get_xml_timeline_template, get_xml_point, get_xml_targetwell, \
     XML_NAMESPACES, replace_namespace_tag, ET
 import random
-from processing import find_objects_by_threshold, find_objects_by_template_matching, plot_results
+from processing import find_objects_by_threshold, find_objects_by_template_matching, \
+    find_objects_by_multiple_template_matching, plot_results
 import warnings
 
 X_OFFSET_PX = -140
@@ -44,7 +45,7 @@ def main():
     parser.add_argument('-p', '--plot_output', type=bool, default=True,
                         help='Whether to generate plots of the results.')
     parser.add_argument('-m', '--method', type=str, default='template',
-                        help="""Method to use for object detection. Either `template` or `threshold`. Make sure you 
+                        help="""Method to use for object detection. Either `template`, 'multi-template' or `threshold`. Make sure you 
                         specify the required arguments for the method you chose.""")
     parser.add_argument('-nx', '--n_tiles_x', type=int, default=4, help='Number of tiles per well in x.')
     parser.add_argument('-ny', '--n_tiles_y', type=int, default=5, help='Number of tiles per well in y.')
@@ -54,7 +55,8 @@ def main():
     parser.add_argument('-ot', '--object_threshold', type=float, default=0.5,
                         help='Threshold [0.0 - 1.0] for rejecting objects (default 0.5).')
     parser.add_argument('-t', '--template_path', type=str, default=None,
-                        help='Full path to template stitched_ds. Default is to search for `template.tif` in the folder.')
+                        help="""Full path to template stitched_ds. Default is to search for `template.tif` in the folder.
+                        If method 'multi-template' is used, all tiff files in the folder will be used as template.""")
 
     # Thresholding arguments
     parser.add_argument('-s', '--sigma', type=float, default=7,
@@ -99,6 +101,14 @@ def main():
                                                                      n_objects_per_site=args.n_objects_per_site,
                                                                      well=well,
                                                                      )
+        elif args.method == 'multi-template':
+            objects, non_objects = find_objects_by_multiple_template_matching(stitched_ds,
+                                                                              object_threshold=args.object_threshold,
+                                                                              template_path=args.template_path,
+                                                                              downsampling=args.downsampling,
+                                                                              n_objects_per_site=args.n_objects_per_site,
+                                                                              well=well,
+                                                                              )
         elif args.method == 'threshold':
             objects, non_objects = find_objects_by_threshold(stitched_ds,
                                                              sigma=args.sigma,


### PR DESCRIPTION
This adds two new options for the method argument in processing.py and processing_with_mes_generation.py. The two options are:

1. **multi-template**: let's the user provide a folder of templates. Each template will be matched to the stitched overview. Useful if someone needs to find back multiple sites that were imaged on a different microscope (e.g. visiscope).
2. **manual**: let's the user provide manual annotations for sites that should be imaged in a napari viewer that is opened upon execution. 